### PR TITLE
Add find-renames flag (-M)

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,14 +91,20 @@ var run = function(command, callback) {
 
 var codeToStatus = function(code) {
     /* ===============================================================================================================================
-     ** PER git diff-index --help
-     ** --diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]
-     **     Select only files that are Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R), have their type (i.e. regular
-     **     file, symlink, submodule, ...) changed (T), are Unmerged (U), are Unknown (X), or have had their pairing Broken (B). Any
-     **     combination of the filter characters (including none) can be used. When * (All-or-none) is added to the combination, all
-     **     paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches
-     **     other criteria, nothing is selected.
-     ** ============================================================================================================================ */
+    ** PER docs at https://git-scm.com/docs/git-diff-index
+    ** Possible status letters are:
+    **   A: addition of a file
+    **   C: copy of a file into a new one
+    **   D: deletion of a file
+    **   M: modification of the contents or mode of a file
+    **   R: renaming of a file
+    **   T: change in the type of the file
+    **   U: file is unmerged (you must complete the merge before it can be committed)
+    **   X: "unknown" change type (most probably a bug, please report it)
+    **
+    ** Status letters C and R are always followed by a score (denoting the percentage of similarity between the source and target of the move or copy).
+    ** Status letter M may be followed by a score (denoting the percentage of dissimilarity) for file rewrites.
+    ** ============================================================================================================================ */
 
     var map = {
         "A": "Added",
@@ -112,7 +118,7 @@ var codeToStatus = function(code) {
         "B": "Broken"
     }
 
-    return map[code];
+    return map[code.charAt(0)];
 }
 
 var stdoutToResultsObject = function(stdout) {
@@ -125,7 +131,7 @@ var stdoutToResultsObject = function(stdout) {
         if (line != "") {
             var parts = line.split("\t");
             var result = {
-                filename: parts[1],
+                filename: parts[2] || parts[1],
                 status: codeToStatus(parts[0])
             }
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var sgf = function(filter, callback) {
         if (err) {
             callback(err);
         } else {
-            var command = "git diff-index --cached --name-status --diff-filter=" + filter + " " + head;
+            var command = "git diff-index --cached --name-status -M --diff-filter=" + filter + " " + head;
             run(command, function(err, stdout, stderr) {
                 if (err || stderr) {
                     callback(err || new Error(stderr));

--- a/test/eval.js
+++ b/test/eval.js
@@ -106,6 +106,28 @@ describe("As a module", function() {
             });
         });
 
+        it("I should find renames", function(done) {
+            addAndCommitFile(function(err, data) {
+                if (err) {
+                    done(err);
+                } else {
+                    var newFileName = randomFileName([8, 3]);
+
+                    moveFile({
+                        oldFileName: data.filename,
+                        newFileName: newFileName
+                    }, function(err) {
+                        var sgf = newSGF();
+                        sgf(asyncCatch(done, function(results) {
+                            results.length.should.equal(1);
+                            results[0].filename.should.equal(newFileName);
+                            results[0].status.should.equal("Renamed");
+                        }));
+                    });
+                }
+            });
+        });
+
         it("if includeContent is set to true I should return the file paths, their git status and the content", function(done) {
             addFile(function(err, data) {
                 var sgf = newSGF();

--- a/test/test.js
+++ b/test/test.js
@@ -60,7 +60,7 @@ newGit = function(callback) {
     run("rm -rf .git && git init", callback);
 }
 
-var randomFileName = function(lengths) {
+randomFileName = function(lengths) {
     var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     var filename = randomString(possible, lengths[0]);
     for (var i = 1; i < lengths.length; i++) {
@@ -82,6 +82,25 @@ var randomString = function(possible, length) {
     }
 
     return text;
+}
+
+moveFile = function(opts, callback) {
+    var oldPath = test_folder + "/" + opts.oldFileName;
+    var newPath = test_folder + "/" + opts.newFileName;
+
+    fs.rename(oldPath, newPath, function(err) {
+        if (err) {
+            callback(err);
+        } else {
+            run("git add " + opts.oldFileName + " " + opts.newFileName, function(err, stdout, stderr) {
+                if (err || stderr) {
+                    callback(err || new Error(stderr));
+                } else {
+                    callback(null, opts);
+                }
+            });
+        }
+    });
 }
 
 newFile = function(opts, callback) {


### PR DESCRIPTION
According to my research, `git diff-index` does not find renames unless explicitly told to do so via the `-M` flag (https://git-scm.com/docs/git-diff-index#git-diff-index--Mltngt) which renders the `R` filter useless. This fixes that by adding said flag to the command.