### PR TITLE
use command result instead of default first head

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,12 +35,20 @@ sgf.cwd = process.cwd();
 sgf.debug = false;
 sgf.includeContent = false;
 
-sgf.firstHead = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+// sgf.firstHead = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 sgf.getHead = function(callback) {
     run("git rev-parse --verify HEAD", function(err, stdout, stderr) {
         if (err && err.message.indexOf("fatal: Needed a single revision")!==-1) {
-            callback(null, sgf.firstHead);
+            // callback(null, sgf.firstHead);
+            run("git hash-object -t tree /dev/null", function(err, stdout, stderr) {
+                if (err || stderr) {
+                    callback(err || new Error("STDERR: " + stderr));
+                } else {
+                    stdout = stdout.replace("\n", "");
+                    callback(null, stdout);
+                }
+            });
         } else if (err || stderr) {
             callback(err || new Error("STDERR: " + stderr));
         } else {


### PR DESCRIPTION
I think it's a better way to use command-exec-result as the firstHead of an empty git, rather than a default SHA1.

What do you think?

Here are the references:

https://stackoverflow.com/questions/9765453/is-gits-semi-secret-empty-tree-object-reliable-and-why-is-there-not-a-symbolic
https://git-scm.com/docs/git-hash-object

Thanks.
