### PR TITLE
Allow passing a `relative` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,17 @@ var spawn = require("child_process").spawn;
 var fs = require("fs");
 
 
-var sgf = function (filter, callback) {
-    if (typeof filter === 'function') {
-        callback = filter;
-        filter = undefined;
+var sgf = function (options = {}, callback) {
+    const typeOfOptions = typeof options;
+    let filter;
+
+    if (typeOfOptions === 'function') {
+      callback = options;
+      filter = undefined;
+    } else if (typeOfOptions === 'string') {
+      filter = options;
+    } else {
+      filter = options.filter;
     }
 
     if (typeof callback === 'undefined') {
@@ -14,15 +21,15 @@ var sgf = function (filter, callback) {
                 if (err)
                     return reject(err);
                 resolve(head);
-            });
+            }, options);
         });
     } else {
-        _sgf(filter, callback);
+        _sgf(filter, callback, options);
     }
 };
 
 
-function _sgf (filter, callback) {
+function _sgf (filter, callback, options) {
     if (typeof filter === 'undefined')
         filter = 'ACDMRTUXB';
 
@@ -32,6 +39,9 @@ function _sgf (filter, callback) {
         } else {
             var command = "git -c core.quotepath=false diff-index --cached --name-status";
 
+            if (options.relative) {
+                command += " --relative";
+            }
             if (filter.indexOf('R') !== -1) {
                 command += " -M";
             }

--- a/test/eval.js
+++ b/test/eval.js
@@ -235,6 +235,33 @@ describe("As a module", function() {
             });
         });
 
+        describe("if the first param is an object", function() {
+            describe("and a filter is set", function() {
+                it("I should return a promise and resolve the status of staged files", function(done) {
+                    addAndCommitFile(function(err, data) {
+                        if (err) {
+                            done(err);
+                        } else {
+                            var newFileName = randomFileName([8, 3]);
+        
+                            moveFile({
+                                oldFileName: data.filename,
+                                newFileName: newFileName
+                            }, function(err) {
+                                var sgf = newSGF();
+                                sgf({ filter: 'A', relative: true }).then(function(results) {
+                                    results.length.should.equal(1);
+                                    results[0].filename.should.equal(newFileName);
+                                    results[0].status.should.equal("Added");
+                                    done();
+                                }).catch(done);
+                            });
+                        }
+                    });
+                });
+            });
+        });
+
         it("readFile will aysnc read a file and return its content", function(done) {
             addFile(function(err, data) {
                 var sgf = newSGF();


### PR DESCRIPTION
Hi @mcwhittemore,

thanks a lot for maintaining this project!

At our company, we have a lot of projects, where the frontend (containing the package.json) is located in a subfolder and therefore not on the same level as the `.git` directory. For this to work, we need to pass the `--relative` param to `git diff-index`.

I added the possibility to pass an object to SGF as the first param. Via this object, the user could set `relative: true` and also `filter: …`. This should not be a breaking change, as they could still simply pass a string (or the callback) as the first param, which would be used for the filter as it was before.

Hope this can be merged. Thank you!